### PR TITLE
Fix docs preview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*Manifest.toml
+docs/build

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,6 @@
-  
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+ThreadSafeDicts = "4239201d-c60e-5e0a-9702-85d713665ba7"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,13 +1,13 @@
 # ThreadSafeDicts.jl
 A thread-safe Dict type for Julia programming
-<br />
+<br>
 <img src="https://github.com/wherrera10/ThreadSafeDicts.jl/blob/master/docs/src/spool.png">
-<br /><br />
+<br><br>
 
 
 ## Structs and Functions
-<br />
-    
+<br>
+
     struct ThreadSafeDict{K, V} <: AbstractDict{K, V}
         dlock::Threads.SpinLock
         d::Dict
@@ -15,48 +15,48 @@ A thread-safe Dict type for Julia programming
         ThreadSafeDict{K, V}(itr) where V where K = new(Threads.SpinLock(), Dict{K, V}(itr))
     end
     ThreadSafeDict() = ThreadSafeDict{Any,Any}()
-    ThreadSafeDict(pairs::Vector{Pair{K,V}})   
-<br />
+    ThreadSafeDict(pairs::Vector{Pair{K,V}})
+<br>
 
-Struct and constructor for ThreadSafeDict. There is one lock per Dict struct. All functions lock this lock, pass 
+Struct and constructor for ThreadSafeDict. There is one lock per Dict struct. All functions lock this lock, pass
 arguments to the d member Dict, unlock the spinlock, and then return what is returned by the Dict.
-<br /><br />
+<br><br>
 
     getindex(dic::ThreadSafeDict, k)
-<br />
+<br>
 
     setindex!(dic::ThreadSafeDict, k, v)
-<br />
+<br>
 
     haskey(dic::ThreadSafeDict, k)
-<br />
+<br>
 
     get(dic::ThreadSafeDict, k, v)
-<br />
+<br>
 
     get!(dic::ThreadSafeDict, k, v)
-<br />
+<br>
 
     pop!(dic::ThreadSafeDict)
-<br />
+<br>
 
     empty!(dic::ThreadSafeDict)
-<br />
+<br>
 
     delete!(dic::ThreadSafeDict, k)
-<br />
+<br>
 
     length(dic::ThreadSafeDict)
-<br />
+<br>
 
     iterate(dic::ThreadSafeDict)
-<br />
+<br>
 
     iterate(dic::ThreadSafeDict, i)
-<br />
+<br>
 
     print(io::IO, dic::ThreadSafeDict)
-<br /><br />
+<br><br>
 
 All of the above methods work as in those of the base Dict type. However, they all
 lock a spinlock prior to passing the arguments to a base Dict within the struct, then
@@ -69,7 +69,7 @@ thread access to the underlying Dict is serialized per ThreadSafeDict.
 ## Installation
 
 You may install the package from Github in the usual way, or to install the current master copy:
-        
+
     using Pkg
     Pkg.add("http://github.com/wherrera10/ThreadSafeDicts.jl")
-    
+


### PR DESCRIPTION
Change `<br />` tags to `<br>` which makes markdown preview work properly. Also adds the package as a docs dependency, which makes the docs environment work.