### PR TITLE
Make the underlying Dict a concrete type

### DIFF
--- a/src/ThreadSafeDicts.jl
+++ b/src/ThreadSafeDicts.jl
@@ -15,7 +15,7 @@ arguments to the d member Dict, unlock the spinlock, and then return what is ret
 """
 struct ThreadSafeDict{K, V} <: AbstractDict{K, V}
     dlock::Threads.SpinLock
-    d::Dict
+    d::Dict{K, V}
     ThreadSafeDict{K, V}() where V where K = new(Threads.SpinLock(), Dict{K, V}())
     ThreadSafeDict{K, V}(itr) where V where K = new(Threads.SpinLock(), Dict{K, V}(itr))
 end


### PR DESCRIPTION
This is my attempt to fix my issue:
https://github.com/wherrera10/ThreadSafeDicts.jl/issues/14

The underlying Dict is changed from an abstract type to a concrete type `Dict{K, V}`. It's a simple fix to improve type stability. All the tests pass.