### PR TITLE
ThreadSafeDict(itr) uses specific types rather than {Any, Any}. 

### DIFF
--- a/src/ThreadSafeDicts.jl
+++ b/src/ThreadSafeDicts.jl
@@ -16,10 +16,15 @@ struct ThreadSafeDict{K, V} <: AbstractDict{K, V}
     dlock::Threads.SpinLock
     d::Dict{K, V}
     ThreadSafeDict{K, V}() where V where K = new(Threads.SpinLock(), Dict{K, V}())
+    ThreadSafeDict{K, V}(d::Dict{K, V}) where V where K = new(Threads.SpinLock(), d)
     ThreadSafeDict{K, V}(itr) where V where K = new(Threads.SpinLock(), Dict{K, V}(itr))
 end
+ThreadSafeDict(d::Dict{K, V}) where V where K = ThreadSafeDict{K, V}(d)
 ThreadSafeDict() = ThreadSafeDict{Any,Any}()
-ThreadSafeDict(itr) = ThreadSafeDict{Any, Any}(itr) # for issue #12
+function ThreadSafeDict(itr)
+    d = Dict(itr)
+    ThreadSafeDict(d)
+end
 
 """
     getindex(dic::ThreadSafeDict, k)


### PR DESCRIPTION
With the new commit, we have
```
julia> ThreadSafeDict(i => 2*i for i in 1:5)
ThreadSafeDict{Int64, Int64} with 5 entries:
  5 => 10
  4 => 8
  2 => 4
  3 => 6
  1 => 2
```
where you get a specific type `{Int, Int}` rather than `{Any, Any}`.
To support this, I also added a constructor `ThreadSafeDict(d::Dict{K, V})`.